### PR TITLE
Added [MetaJSON] to dist.ini, so releases will include META.json

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    * Added [MetaJSON] to dist.ini, so releases will include META.json
+
 0.04      2013-09-14 11:41:46 Europe/Paris
 
     * Added missing dependency on Moo

--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,7 @@ copyright_holder = Alexis Sukrieh
 copyright_year   = 2013
 
 [@Basic]
+[MetaJSON]
 
 [TestRelease]
 [PodWeaver]


### PR DESCRIPTION
Hi Alexis,

This is a small PR to add a META.json file to the next release. Having a json metadata file gives better dependency metadata, which is useful for tools, and river position calculation.

Cheers,
Neil
